### PR TITLE
Add Travis status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GHCL – GitHub ChangeLog Generator
 
+[![Build Status](https://travis-ci.org/digitalocean/github-changelog-generator.svg?branch=master)](https://travis-ci.org/digitalocean/github-changelog-generator)
+
 A changelog generator for GitHub.
 
 The generator works by,


### PR DESCRIPTION
Adds the TravisCI status badge, and kicks off the first test to see if the config is setup correctly.