### PR TITLE
Allow GitHub API token not to be passed

### DIFF
--- a/ghcl/ghcl.go
+++ b/ghcl/ghcl.go
@@ -57,9 +57,13 @@ type GitHubChangelogService struct {
 // The apiURL can be used to specify a different URL
 // to access the GitHub API, typically used for GitHub enterprise customers.
 func NewGitHubChangelogService(organization, repository, token, apiURL string) *GitHubChangelogService {
-	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-	client := github.NewClient(oauth2.NewClient(context.Background(),
-		tokenSource))
+	client := github.NewClient(nil)
+
+	if token != "" {
+		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+		client = github.NewClient(oauth2.NewClient(context.Background(),
+			tokenSource))
+	}
 
 	if apiURL != "" {
 		baseURL, err := url.Parse(apiURL)


### PR DESCRIPTION
On some CI machines, there's a default `GITHUB_TOKEN` that is left unset. Prior to this change, we'd see that there's that environment variable, and attempt to initialize our GitHub API client with it. This breaks every API call however, because the GitHub API client decides to send an empty string as an API token on every call in this particular case.

Now, if that environment variable exists but is unset, we don't try to send an empty string as an API token.