### PR TITLE
ci: update go version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ 1.16.x, 1.17.x, 1.18.x ]
+        go-version: [ 1.19.x, 1.20.x ]
 
     runs-on: ubuntu-latest
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/digitalocean/github-changelog-generator
 
-go 1.17
+go 1.20
 
 require (
 	github.com/google/go-github v17.0.0+incompatible


### PR DESCRIPTION
Updates the Go version in the mod file and in the GitHub Actions tests.