### PR TITLE
Switch from master to main in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   pull_request_target:
   push:
     branches:
-    - master
+    - main
 
 jobs:
   test:


### PR DESCRIPTION
This was the last of the repos owned by this team to still be using `master` for its default branch. I've now renamed it to `main` for consistency. This updates the workflow to reflect that.