### PR TITLE
Update build status badge for GHA.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GHCL – GitHub ChangeLog Generator
 
-[![Build Status](https://travis-ci.org/digitalocean/github-changelog-generator.svg?branch=master)](https://travis-ci.org/digitalocean/github-changelog-generator)
+[![Build Status](https://github.com/digitalocean/github-changelog-generator/actions/workflows/test.yml/badge.svg)](https://github.com/digitalocean/github-changelog-generator/actions/workflows/test.yml)
 
 A changelog generator for GitHub.
 


### PR DESCRIPTION
Another tiny bit of clean up. We still had a TravisCI badge on the README despite switching to Actions long ago.